### PR TITLE
Fix adding '--dev' option

### DIFF
--- a/composer.el
+++ b/composer.el
@@ -82,8 +82,8 @@
   (unless package
     (error "A argument `PACKAGE' is required"))
   (let ((args (list package)))
-    (when is-dev (append "--dev"))
-    (apply 'composer-mode--composer-execute "require" (nreverse args))))
+    (when is-dev (push "--dev" args))
+    (apply 'composer-mode--composer-execute "require" args)))
 
 (defun composer-find-json-file ()
   "Open composer.json of the project."


### PR DESCRIPTION
- append argument is missed
- append is not a destructive function
- passing string argument to `append` is wrong as usual. Because it is treated as list of character. For example `(append "abc" '("def"))` returns `(97 98 99 "def")`.
