### PR TITLE
Add update and run-script commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,16 +12,19 @@ See [[https://getcomposer.org/doc/][Composer Documentation]].  =composer.el= sup
 
 ** Commands
 
-| command                       | description                                                |
-|-------------------------------+------------------------------------------------------------|
-| =M-x composer=                | Run =composer= sub command (with completing read)          |
-| =C-u M-x composer=            | Run =composer= (global) sub command (with completing read) |
-| =M-x composer-install=        | Run =composer install= command                             |
-| =M-x composer-require=        | Run =composer require= command                             |
-| =C-u M-x composer-require=    | Run =composer require --dev= command                       |
-| =M-x composer-dump-autoload=  | Run =composer dump-autoload= command                       |
-| =M-x composer-find-json-file= | Open =composer.json= of the project                        |
-| =M-x composer-view-lock-file= | Open =composer.lock= of the project (as read-only)         |
+| command                               | description                                                |
+|---------------------------------------+------------------------------------------------------------|
+| =M-x composer=                        | Run =composer= sub command (with completing read)          |
+| =C-u M-x composer=                    | Run =composer= (global) sub command (with completing read) |
+| =M-x composer-install=                | Run =composer install= command                             |
+| =M-x composer-require=                | Run =composer require= command                             |
+| =C-u M-x composer-require=            | Run =composer require --dev= command                       |
+| =M-x composer-update=                 | Run =composer update= command                              |
+| =M-x composer-dump-autoload=          | Run =composer dump-autoload= command                       |
+| =M-x composer-run-script=             | Run =command= in =vendor/bin=                              |
+| =M-x composer-run-vendor-bin-command= | Run =composer run-script= command                          |
+| =M-x composer-find-json-file=         | Open =composer.json= of the project                        |
+| =M-x composer-view-lock-file=         | Open =composer.lock= of the project (as read-only)         |
 
 ** API
 *** =composer-get-config(name)=

--- a/composer.el
+++ b/composer.el
@@ -154,6 +154,13 @@
         (error "%s command is not exists" command)
       command-path)))
 
+(defun composer--get-scripts ()
+  "Return script names in composer.json, excluding pre and post hooks."
+  (let ((output (composer--command-execute "run" "-l")))
+    (seq-filter (lambda (script) (not (member script '("pre" "post"))))
+                (mapcar (lambda (line) (car (s-split-words line)))
+                        (s-split "\n" (cadr (s-split "Scripts:\n" output)))))))
+
 (defun composer--command-async-execute (sub-command &rest args)
   "Asynchronous execute `composer.phar' command SUB-COMMAND by ARGS."
   (let ((default-directory (or (composer--find-composer-root default-directory)
@@ -298,6 +305,12 @@ https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md"
     (if command-path
         (compile command-path)
       (error "`%s' is not executable file" command))))
+
+;;;###autoload
+(defun composer-run-script (script)
+  "Run script `SCRIPT` as defined in the composer.json."
+  (interactive (list (completing-read "Run scripts: " (composer--get-scripts))))
+  (composer--command-async-execute "run-script" script))
 
 ;;;###autoload
 (defun composer-self-update ()

--- a/composer.el
+++ b/composer.el
@@ -34,6 +34,7 @@
 ;;  - C-u M-x composer  - Run composer (global) sub command (with completing read)
 ;;  - M-x composer-install  - Run composer install command
 ;;  - M-x composer-require  - Run composer require command
+;;  - M-x composer-update  - Run composer update command
 ;;  - C-u M-x composer-require  - Run composer require --dev command
 ;;  - M-x composer-dump-autoload - Run composer dump-autoload command
 ;;  - M-x composer-find-json-file  - Open composer.json of the project
@@ -267,6 +268,12 @@ https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md"
   (let ((args (list package)))
     (when is-dev (push "--dev" args))
     (apply 'composer--command-async-execute "require" args)))
+
+;;;###autoload
+(defun composer-update ()
+  "Execute `composer.phar update' command."
+  (interactive)
+  (composer--command-async-execute "update"))
 
 ;;;###autoload
 (defun composer-find-json-file ()


### PR DESCRIPTION
This PR adds the option to run `composer update` and `composer-run-script`. The run script command lets the user choose between scripts similar to `composer-run-vendor-bin-command` but now only scripts (excluding pre and post hooks) that are defined in your `composer.json`'s `scripts` are shown.